### PR TITLE
Fetchcleanup

### DIFF
--- a/webapp/client/src/Routes/Graph.tsx
+++ b/webapp/client/src/Routes/Graph.tsx
@@ -81,11 +81,12 @@ export default function Graph() {
       setData([]);
       return;
     } 
-    // we have validated, so now send request
-    getDailySamples(date);
+    // we have validated, so now wait for timeout and send request
+    const timeoutId = setTimeout(() => getDailySamples(date), 1000);
 
-    // cancel fetch if date has changed
+    // cancel fetch if date has changed or component unmounts before timeout
     return (() => {
+      clearTimeout(timeoutId);
       if (sampleFetchAbortController.current) {
         sampleFetchAbortController.current.abort();
       }

--- a/webapp/client/src/Routes/ReadingsTable.tsx
+++ b/webapp/client/src/Routes/ReadingsTable.tsx
@@ -22,9 +22,10 @@ export default function Table() {
   }, [setData]);
 
   useEffect(() => {
-    getSamples(page, linesPerPage);
+    const timeoutId = setTimeout(() => getSamples(page, linesPerPage), 1000);
 
     return (() => {
+      clearTimeout(timeoutId);
       if (readingsFetchAbortController.current) {
         readingsFetchAbortController.current.abort();
       }


### PR DESCRIPTION
Cleans up client-side fetch requests if component is destroyed using AbortController. Additionally, adds a small delay before sending GET requests to server in order to not overwhelm API while scrolling through dates on the graph page.